### PR TITLE
Remove mongodb credentials from this file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@
 #spring.jpa.hibernate.ddl-auto=update
 #debug=true
 
-spring.data.mongodb.uri=mongodb+srv://commAdmin:commPassword@mum-comm.tbq5c.mongodb.net/retryWrites=true&w=majority
+spring.data.mongodb.uri=
 spring.data.mongodb.database=commDB
 
 #smtp mail properties


### PR DESCRIPTION
The production credentials are in this file please remove the mongodb credentials. Or set this repository to private.

I did a test to connect and list the databases:
```
Connected to mongo server.
Databases:
 - commDB
 - admin
 - local
```

Remember when removing the credentials please also make sure you clear the commit history:
https://stackoverflow.com/questions/13716658/how-to-delete-all-commit-history-in-github